### PR TITLE
feat: 프로필 페이지 (조회/닉네임 수정/탈퇴) + User IDOR 방지

### DIFF
--- a/backend/src/main/java/com/moyalist/backend/controller/UserController.java
+++ b/backend/src/main/java/com/moyalist/backend/controller/UserController.java
@@ -7,6 +7,7 @@ import com.moyalist.backend.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -34,14 +35,18 @@ public class UserController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<UserResponseDto> updateUser(@PathVariable Long id,
-                                                      @Valid @RequestBody UserUpdateRequest request) {
-        return ResponseEntity.ok(userService.updateUser(id, request));
+    public ResponseEntity<UserResponseDto> updateUser(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody UserUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateUser(userId, id, request));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
-        userService.deleteUser(id);
+    public ResponseEntity<Void> deleteUser(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id) {
+        userService.deleteUser(userId, id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/moyalist/backend/service/UserService.java
+++ b/backend/src/main/java/com/moyalist/backend/service/UserService.java
@@ -6,6 +6,7 @@ import com.moyalist.backend.dto.UserUpdateRequest;
 import com.moyalist.backend.entity.User;
 import com.moyalist.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,7 +51,10 @@ public class UserService {
     }
 
     @Transactional
-    public UserResponseDto updateUser(Long id, UserUpdateRequest request) {
+    public UserResponseDto updateUser(Long userId, Long id, UserUpdateRequest request) {
+        if (!userId.equals(id)) {
+            throw new AccessDeniedException("본인의 프로필만 수정할 수 있습니다.");
+        }
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + id));
 
@@ -59,7 +63,10 @@ public class UserService {
     }
 
     @Transactional
-    public void deleteUser(Long id) {
+    public void deleteUser(Long userId, Long id) {
+        if (!userId.equals(id)) {
+            throw new AccessDeniedException("본인의 계정만 삭제할 수 있습니다.");
+        }
         if (!userRepository.existsById(id)) {
             throw new IllegalArgumentException("사용자를 찾을 수 없습니다: " + id);
         }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Layout from './components/Layout';
 import MainPage from './pages/MainPage';
 import QuestionListPage from './pages/QuestionListPage';
 import QuestionDetailPage from './pages/QuestionDetailPage';
+import ProfilePage from './pages/ProfilePage';
 import TagListPage from './pages/TagListPage';
 import LoginPage from './pages/LoginPage';
 import AuthCallbackPage from './pages/AuthCallbackPage';
@@ -27,6 +28,7 @@ function AppRoutes() {
       <Route element={<Layout />}>
         <Route path="questions" element={<QuestionListPage />} />
         <Route path="questions/:id" element={<PrivateRoute><QuestionDetailPage /></PrivateRoute>} />
+        <Route path="profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />
         {/* 태그는 서버 데이터 → 로그인 필요 */}
         <Route path="tags" element={<PrivateRoute><TagListPage /></PrivateRoute>} />
       </Route>

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,0 +1,20 @@
+import api from './client';
+import type { User } from '../types';
+
+export interface UserUpdatePayload {
+  name: string;
+}
+
+export const userApi = {
+  getById(id: number) {
+    return api.get<User>(`/users/${id}`);
+  },
+
+  update(id: number, data: UserUpdatePayload) {
+    return api.put<User>(`/users/${id}`, data);
+  },
+
+  delete(id: number) {
+    return api.delete(`/users/${id}`);
+  },
+};

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -63,10 +63,13 @@ function Header({ onMenuClick, logoCenter = false }: HeaderProps) {
           </div>
         ) : (
           <div className="flex items-center gap-2">
-            <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg">
+            <button
+              onClick={() => navigate('/profile')}
+              className="flex items-center gap-2 px-3 py-1.5 hover:bg-slate-200/50 rounded-lg transition-colors"
+            >
               <User size={16} className="text-slate-600" />
               <span className="text-xs text-slate-600">{user.name}</span>
-            </div>
+            </button>
             <button
               onClick={logout}
               className="flex items-center gap-1 px-3 py-1.5 hover:bg-slate-200/50 rounded-lg transition-colors text-slate-500"

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Pencil, Check, X, LogOut, Trash2 } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
+import { userApi } from '../api/users';
+
+const PROVIDER_LABEL: Record<string, string> = {
+  google: 'Google',
+  kakao: 'Kakao',
+  local: '이메일',
+};
+
+export default function ProfilePage() {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [nameError, setNameError] = useState('');
+
+  if (!user) return null;
+
+  const handleEditStart = () => {
+    setEditName(user.name);
+    setNameError('');
+    setIsEditing(true);
+  };
+
+  const handleEditCancel = () => {
+    setIsEditing(false);
+    setNameError('');
+  };
+
+  const handleSave = async () => {
+    if (!editName.trim()) {
+      setNameError('닉네임을 입력해주세요.');
+      return;
+    }
+    setSaving(true);
+    try {
+      await userApi.update(user.id, { name: editName.trim() });
+      // AuthContext의 user를 갱신하려면 페이지를 새로고침하는 게 가장 단순
+      window.location.reload();
+    } catch {
+      setNameError('저장에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    const confirmed = window.confirm(
+      '정말 탈퇴하시겠습니까?\n작성한 질문과 태그가 모두 삭제되며 복구할 수 없습니다.'
+    );
+    if (!confirmed) return;
+
+    try {
+      await userApi.delete(user.id);
+      localStorage.removeItem('token');
+      window.location.href = '/login';
+    } catch {
+      alert('탈퇴 처리 중 오류가 발생했습니다. 다시 시도해주세요.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen px-4 md:px-8 py-8">
+      <div className="max-w-lg mx-auto">
+        <h1 className="text-xl font-bold text-slate-800 mb-8">프로필</h1>
+
+        <div className="bg-white border border-slate-200 rounded-2xl p-8 space-y-6">
+
+          {/* 닉네임 */}
+          <div>
+            <label className="block text-xs font-medium text-slate-400 mb-1.5">닉네임</label>
+            {isEditing ? (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={editName}
+                  onChange={(e) => { setEditName(e.target.value); setNameError(''); }}
+                  className="flex-1 px-3 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:border-slate-500"
+                  autoFocus
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); if (e.key === 'Escape') handleEditCancel(); }}
+                />
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="flex items-center gap-1 px-3 py-2 bg-slate-700 text-white text-sm rounded-lg hover:bg-slate-600 disabled:opacity-40 transition-colors"
+                >
+                  <Check size={14} /> {saving ? '저장 중...' : '저장'}
+                </button>
+                <button
+                  onClick={handleEditCancel}
+                  className="px-3 py-2 text-slate-500 hover:bg-slate-100 rounded-lg transition-colors"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-800">{user.name}</span>
+                <button
+                  onClick={handleEditStart}
+                  className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-lg transition-colors"
+                >
+                  <Pencil size={12} /> 수정
+                </button>
+              </div>
+            )}
+            {nameError && <p className="text-xs text-red-500 mt-1">{nameError}</p>}
+          </div>
+
+          {/* 이메일 */}
+          <div>
+            <label className="block text-xs font-medium text-slate-400 mb-1.5">이메일</label>
+            <span className="text-sm text-slate-800">{user.email}</span>
+          </div>
+
+          {/* 연동 계정 */}
+          <div>
+            <label className="block text-xs font-medium text-slate-400 mb-1.5">연동 계정</label>
+            <span className="text-sm text-slate-800">
+              {PROVIDER_LABEL[user.provider] ?? user.provider}
+            </span>
+          </div>
+
+          {/* 가입일 */}
+          <div>
+            <label className="block text-xs font-medium text-slate-400 mb-1.5">가입일</label>
+            <span className="text-sm text-slate-800">
+              {new Date(user.createdAt).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })}
+            </span>
+          </div>
+        </div>
+
+        {/* 하단 액션 */}
+        <div className="mt-6 flex justify-between">
+          <button
+            onClick={logout}
+            className="flex items-center gap-1.5 px-4 py-2 text-sm text-slate-500 hover:text-slate-700 hover:bg-slate-100 rounded-lg transition-colors"
+          >
+            <LogOut size={15} /> 로그아웃
+          </button>
+          <button
+            onClick={handleDelete}
+            className="flex items-center gap-1.5 px-4 py-2 text-sm text-red-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          >
+            <Trash2 size={15} /> 회원 탈퇴
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,6 +38,8 @@ export interface User {
   name: string;
   email: string;
   profileUrl: string | null;
+  provider: string;
+  createdAt: string;
 }
 
 // 페이지네이션 응답 타입


### PR DESCRIPTION
## Summary
- `UserController` PUT/DELETE에 `@AuthenticationPrincipal` 소유권 검사 추가 (불일치 시 403)
- `User` 타입에 `provider`, `createdAt` 필드 추가
- `/profile` 라우트 신규 (로그인 필요)
- `ProfilePage`: 닉네임 인라인 수정, 연동 계정/이메일/가입일 표시, 로그아웃, 회원 탈퇴
- Header 닉네임 클릭 시 `/profile`로 이동

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)