### PR TITLE
feat: #태그명 자동 파싱 및 인라인 하이라이팅

### DIFF
--- a/frontend/src/components/HashtagInput.tsx
+++ b/frontend/src/components/HashtagInput.tsx
@@ -1,0 +1,98 @@
+import { useRef } from 'react';
+import { splitByHashtags } from '../utils/parseHashtags';
+
+interface HashtagInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  className?: string;
+  autoFocus?: boolean;
+}
+
+/**
+ * #태그명을 실시간으로 하이라이팅하는 텍스트 입력 컴포넌트.
+ *
+ * 구현 방식 (오버레이):
+ * - wrapper div (position: relative)
+ *   ├── overlay div  : 하이라이팅된 텍스트를 렌더링 (pointer-events: none)
+ *   └── input        : 실제 입력 받는 레이어 (text: transparent, caret는 보임)
+ *
+ * input에서 스크롤이 발생하면 overlay도 동일한 scrollLeft로 동기화해서
+ * 텍스트 오버플로우 상황에서도 두 레이어가 항상 일치한다.
+ */
+function HashtagInput({
+  value,
+  onChange,
+  onKeyDown,
+  placeholder,
+  className = '',
+  autoFocus = false,
+}: HashtagInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // input이 스크롤될 때 overlay를 동일한 위치로 동기화
+  const syncScroll = () => {
+    if (inputRef.current && overlayRef.current) {
+      overlayRef.current.scrollLeft = inputRef.current.scrollLeft;
+    }
+  };
+
+  const parts = splitByHashtags(value);
+
+  return (
+    <div className={`relative ${className}`}>
+      {/* 오버레이: 하이라이팅 텍스트 레이어 */}
+      <div
+        ref={overlayRef}
+        aria-hidden="true"
+        className="
+          absolute inset-0
+          px-4 py-3
+          text-sm text-slate-800
+          whitespace-pre overflow-hidden
+          pointer-events-none
+          rounded-xl
+        "
+      >
+        {parts.map((part, i) =>
+          part.startsWith('#') && part.length > 1 ? (
+            <span key={i} className="text-blue-500 underline underline-offset-2">
+              {part}
+            </span>
+          ) : (
+            <span key={i}>{part}</span>
+          )
+        )}
+        {/* 빈 문자열일 때 높이 유지용 */}
+        {value.length === 0 && <span>&nbsp;</span>}
+      </div>
+
+      {/* 실제 input: 텍스트는 투명하지만 커서(caret)는 보임 */}
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        onScroll={syncScroll}
+        onKeyUp={syncScroll}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        className="
+          relative w-full
+          px-4 py-3
+          bg-transparent
+          text-sm text-transparent caret-slate-800
+          border border-slate-300/50 rounded-xl
+          focus:outline-none focus:border-slate-400
+          transition-all
+          placeholder:text-slate-400
+        "
+      />
+    </div>
+  );
+}
+
+export default HashtagInput;

--- a/frontend/src/components/QuestionCreateModal.tsx
+++ b/frontend/src/components/QuestionCreateModal.tsx
@@ -3,6 +3,8 @@ import { X, Plus } from 'lucide-react';
 import { questionApi } from '../api/questions';
 import { tagApi } from '../api/tags';
 import { getTagColor } from '../constants/colors';
+import HashtagInput from './HashtagInput';
+import { parseHashtags } from '../utils/parseHashtags';
 import type { Tag } from '../types';
 
 interface QuestionCreateModalProps {
@@ -30,11 +32,26 @@ function QuestionCreateModal({ isOpen, onClose, onCreated }: QuestionCreateModal
 
     try {
       setSubmitting(true);
+
+      // 제목에서 #태그 파싱 후 ID 변환 (없으면 자동 생성)
+      const { cleanTitle, tagNames } = parseHashtags(title);
+      const resolvedIds = [...selectedTagIds];
+      for (const name of tagNames) {
+        const existing = tags.find((t) => t.name.toLowerCase() === name.toLowerCase());
+        if (existing) {
+          if (!resolvedIds.includes(existing.id)) resolvedIds.push(existing.id);
+        } else {
+          const res = await tagApi.create({ name });
+          resolvedIds.push(res.data.id);
+          setTags((prev) => [...prev, res.data]);
+        }
+      }
+
       await questionApi.create({
-        title: title.trim(),
+        title: cleanTitle || title.trim(),
         description: description.trim() || undefined,
         sourceUrl: sourceUrl.trim() || undefined,
-        tagIds: selectedTagIds.length > 0 ? selectedTagIds : undefined,
+        tagIds: resolvedIds.length > 0 ? resolvedIds : undefined,
       });
       // 초기화 후 닫기
       setTitle('');
@@ -85,17 +102,16 @@ function QuestionCreateModal({ isOpen, onClose, onCreated }: QuestionCreateModal
             <label className="block text-sm font-medium text-slate-700 mb-1">
               궁금한 것 <span className="text-red-400">*</span>
             </label>
-            <input
-              type="text"
+            <HashtagInput
               value={title}
-              onChange={(e) => setTitle(e.target.value)}
+              onChange={setTitle}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' && !e.shiftKey && title.trim()) {
                   handleSubmit();
                 }
               }}
-              placeholder="이게 뭐야? 하는 궁금증을 적어보세요"
-              className="w-full px-3 py-2.5 bg-white/50 border border-slate-300/50 rounded-lg text-sm focus:outline-none focus:border-slate-400 focus:bg-white transition-all"
+              placeholder="이게 뭐야? 하는 궁금증을 적어보세요 (#태그 로 태그 추가)"
+              className="w-full bg-white/50"
               autoFocus
             />
           </div>

--- a/frontend/src/pages/QuestionListPage.tsx
+++ b/frontend/src/pages/QuestionListPage.tsx
@@ -4,11 +4,13 @@ import { Plus, Lightbulb, Trash2, Download, X } from 'lucide-react';
 import FilterBar from '../components/FilterBar';
 import QuestionCard from '../components/QuestionCard';
 import QuestionCreateModal from '../components/QuestionCreateModal';
+import HashtagInput from '../components/HashtagInput';
 import { questionApi } from '../api/questions';
 import { tagApi } from '../api/tags';
 import type { Question, Tag } from '../types';
 import { useAuth } from '../context/AuthContext';
 import { guestStorage, type GuestQuestion } from '../utils/guestStorage';
+import { parseHashtags } from '../utils/parseHashtags';
 
 // ─── 로그인 사용자용 ─────────────────────────────────────────────────────────
 
@@ -128,10 +130,22 @@ function AuthenticatedQuestionList() {
     }
   };
 
-  const handleQuickAdd = async (title: string) => {
+  const handleQuickAdd = async (title: string, tagNames: string[]) => {
     if (!title.trim()) return;
     try {
-      await questionApi.create({ title: title.trim() });
+      // 태그명 → ID 변환 (없으면 자동 생성)
+      const tagIds: number[] = [];
+      for (const name of tagNames) {
+        const existing = tags.find((t) => t.name.toLowerCase() === name.toLowerCase());
+        if (existing) {
+          tagIds.push(existing.id);
+        } else {
+          const res = await tagApi.create({ name });
+          tagIds.push(res.data.id);
+          setTags((prev) => [...prev, res.data]);
+        }
+      }
+      await questionApi.create({ title: title.trim(), tagIds: tagIds.length > 0 ? tagIds : undefined });
       fetchQuestions();
     } catch {
       // 실패 시 조용히 처리
@@ -343,24 +357,25 @@ function GuestQuestionCard({
 
 // ─── 공통 컴포넌트 ────────────────────────────────────────────────────────────
 
-function QuickInput({ onSubmit, onDetailClick }: { onSubmit: (title: string) => void; onDetailClick?: () => void }) {
+function QuickInput({ onSubmit, onDetailClick }: { onSubmit: (title: string, tagNames: string[]) => void; onDetailClick?: () => void }) {
   const [value, setValue] = useState('');
 
   const handleSubmit = () => {
     if (!value.trim()) return;
-    onSubmit(value.trim());
+    const { cleanTitle, tagNames } = parseHashtags(value);
+    if (!cleanTitle) return;
+    onSubmit(cleanTitle, tagNames);
     setValue('');
   };
 
   return (
     <div className="flex gap-2">
-      <input
-        type="text"
+      <HashtagInput
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={setValue}
         onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit(); }}
-        placeholder="궁금한 것을 빠르게 입력하세요..."
-        className="flex-1 px-4 py-3 bg-white/50 border border-slate-300/50 rounded-xl text-sm focus:outline-none focus:border-slate-400 focus:bg-white transition-all"
+        placeholder="궁금한 것을 빠르게 입력하세요... (#태그 로 태그 추가)"
+        className="flex-1 bg-white/50 focus-within:bg-white transition-all"
         autoFocus
       />
       {onDetailClick && (

--- a/frontend/src/utils/parseHashtags.ts
+++ b/frontend/src/utils/parseHashtags.ts
@@ -1,0 +1,41 @@
+/**
+ * 입력 문자열에서 #태그명 토큰을 추출한다.
+ *
+ * 규칙:
+ * - `#` 뒤에 오는 공백/`#` 이외의 문자열을 태그로 인식
+ * - 공백 없이 붙여 써도 각각 인식: "#React#hooks" → ["React", "hooks"]
+ * - 태그 토큰은 제목에서 제거하고 앞뒤 공백을 정리한다
+ *
+ * 예시:
+ *   "React useState가 뭐야 #React #hooks"
+ *   → { cleanTitle: "React useState가 뭐야", tagNames: ["React", "hooks"] }
+ */
+export function parseHashtags(text: string): { cleanTitle: string; tagNames: string[] } {
+  const tagNames: string[] = [];
+  const tagRegex = /#([^\s#]+)/g;
+
+  let match;
+  while ((match = tagRegex.exec(text)) !== null) {
+    tagNames.push(match[1]);
+  }
+
+  const cleanTitle = text
+    .replace(/#[^\s#]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return { cleanTitle, tagNames };
+}
+
+/**
+ * 텍스트를 일반 부분과 #태그 부분으로 분리한다. (하이라이팅용)
+ *
+ * `[^\s#]+` 를 사용해 공백 없이 붙인 태그도 각각 분리한다.
+ *
+ * 예시:
+ *   "뭐야 #React #hooks"  → ["뭐야 ", "#React", " ", "#hooks"]
+ *   "뭐야 #React#hooks"   → ["뭐야 ", "#React", "#hooks"]
+ */
+export function splitByHashtags(text: string): string[] {
+  return text.split(/(#[^\s#]+)/g).filter((part) => part.length > 0);
+}


### PR DESCRIPTION
## Summary
- `#태그명` 입력 시 오버레이 방식으로 실시간 하이라이팅 (파란색 밑줄)
- overlay `scrollLeft` 동기화로 텍스트 오버플로우 시에도 정렬 유지
- 등록 시 없는 태그 자동 생성, 있는 태그는 기존 ID 사용
- `#tag1 #tag2`(공백) / `#tag1#tag2`(공백 없음) 모두 인식
- QuickInput, QuestionCreateModal 양쪽에 적용

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)